### PR TITLE
fix(verify-proof): exclusion proof with private neighbor

### DIFF
--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -75,8 +75,10 @@ where
 
     // Last decoded node should have the key that we are looking for.
     last_decoded_node = last_decoded_node.filter(|_| walked_path == key);
+    // For exclusion proofs (expected_value is None), we don't check the privacy flag
+    // because the privacy of an adjacent leaf where the proof terminates is irrelevant.
     if last_decoded_node.as_deref() == expected_value.as_deref()
-        && last_decoded_node_is_private == expected_is_private
+        && (expected_value.is_none() || last_decoded_node_is_private == expected_is_private)
     {
         Ok(())
     } else {
@@ -874,5 +876,65 @@ mod tests {
                 prop_assert!(wrong.is_err(), "Wrong privacy flag must fail");
             }
         });
+    }
+
+    #[test]
+    fn exclusion_proof_near_private_leaf_should_verify() {
+        // Regression test: exclusion proofs should not check the privacy flag of
+        // adjacent leaves where the proof terminates.
+        //
+        // Trie only contains 2 leaves:
+        //
+        // root
+        //  |
+        //  +-- 0x00...10 (public leaf)
+        //  |
+        //  +-- 0x00...20 (private leaf)
+        //
+        // We create 2 exclusion proofs for targets that diverge at the last nibble:
+        // - 0x00...11 should terminate at 0x00...10 (public leaf) and verify.
+        // - 0x00...21 should terminate at 0x00...20 (private leaf) and should also verify.
+        let public_key = Nibbles::unpack(B256::with_last_byte(0x10));
+        let private_key = Nibbles::unpack(B256::with_last_byte(0x20));
+        let public_value = B256::with_last_byte(0x10);
+        let private_value = B256::with_last_byte(0x20);
+        let target_near_public = Nibbles::unpack(B256::with_last_byte(0x11));
+        let target_near_private = Nibbles::unpack(B256::with_last_byte(0x21));
+
+        let retainer = ProofRetainer::from_iter([target_near_public, target_near_private]);
+        let mut hash_builder = HashBuilder::default().with_proof_retainer(retainer);
+        hash_builder.add_leaf(public_key, &public_value[..], false);
+        hash_builder.add_leaf(private_key, &private_value[..], true);
+
+        let root = hash_builder.root();
+        let proofs = hash_builder.take_proof_nodes();
+
+        // Exclusion proof near public leaf should verify
+        let public_proof = proofs.matching_nodes_sorted(&target_near_public);
+        let public_result = verify_proof(
+            root,
+            target_near_public,
+            None,
+            false,
+            public_proof.iter().map(|(_, node)| node),
+        );
+        assert!(
+            public_result.is_ok(),
+            "expected exclusion near public leaf to verify, got: {public_result:?}"
+        );
+
+        // Exclusion proof near private leaf should also verify (this was the bug)
+        let private_proof = proofs.matching_nodes_sorted(&target_near_private);
+        let private_result = verify_proof(
+            root,
+            target_near_private,
+            None,
+            false,
+            private_proof.iter().map(|(_, node)| node),
+        );
+        assert!(
+            private_result.is_ok(),
+            "expected exclusion near private leaf to verify, got: {private_result:?}"
+        );
     }
 }


### PR DESCRIPTION
Fixes veridise [issue 802](https://app.audithub.dev/app/organizations/224/projects/621/project-viewer?version=1453&issueId=802).

> An exclusion proof in this trie should show that a key is absent by presenting the path of nodes from the root toward that key until the search cannot continue. The verifier walks the proof nodes in order, choosing the next child based on the key’s next unit of the path. The proof is valid if the search reaches either (a) a branch node that does not contain the required child, or (b) a leaf node whose stored key does not match the target key. In both cases, the key is absent, so the proof should succeed without any requirement on leaf metadata.
>
> In verify_proof, the privacy flag is tracked whenever a leaf is decoded. If an exclusion proof terminates at a divergent leaf, the verifier still compares the recorded privacy flag against expected_is_private. This rejects valid exclusion proofs when the adjacent leaf is private and the caller expects a public absence.