### PR TITLE
fix(verify-proof): in-place private leafs cause bug

### DIFF
--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -122,7 +122,9 @@ fn process_trie_node(
     last_decoded_node_is_private: &mut bool,
 ) -> Result<Option<NodeDecodingResult>, ProofVerificationError> {
     let node = match node {
-        TrieNode::Branch(branch) => process_branch(branch, walked_path, key)?,
+        TrieNode::Branch(branch) => {
+            process_branch(branch, walked_path, key, last_decoded_node_is_private)?
+        }
         TrieNode::Extension(extension) => {
             walked_path.extend(&extension.key);
             if extension.child.is_hash() {
@@ -151,6 +153,7 @@ fn process_branch(
     mut branch: BranchNode,
     walked_path: &mut Nibbles,
     key: &Nibbles,
+    last_decoded_node_is_private: &mut bool,
 ) -> Result<Option<NodeDecodingResult>, ProofVerificationError> {
     if let Some(next) = key.get(walked_path.len()) {
         let mut stack_ptr = branch.as_ref().first_child_index();
@@ -170,7 +173,12 @@ fn process_branch(
                                 // encoded, leaf children, as anything else overflows this branch
                                 // node, making it impossible to be encoded in-place in the first
                                 // place.
-                                return process_branch(child_branch, walked_path, key);
+                                return process_branch(
+                                    child_branch,
+                                    walked_path,
+                                    key,
+                                    last_decoded_node_is_private,
+                                );
                             }
                             TrieNode::Extension(child_extension) => {
                                 walked_path.extend(&child_extension.key);
@@ -188,6 +196,7 @@ fn process_branch(
                                             extension_child_branch,
                                             walked_path,
                                             key,
+                                            last_decoded_node_is_private,
                                         );
                                     }
                                     node @ (TrieNode::EmptyRoot
@@ -199,6 +208,7 @@ fn process_branch(
                             }
                             TrieNode::Leaf(child_leaf) => {
                                 walked_path.extend(&child_leaf.key);
+                                *last_decoded_node_is_private = child_leaf.is_private;
                                 return Ok(Some(NodeDecodingResult::Value(child_leaf.value)));
                             }
                             TrieNode::EmptyRoot => {
@@ -790,6 +800,125 @@ mod tests {
             Nibbles::from_nibbles([0x4, 0x1, 0x3, 0xb]),
             Some(vec![0x64]),
             is_private,
+            proof.clone(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn private_inplace_leaf_proof_verification() {
+        // Same trie structure as proof_verification_with_node_encoded_in_place,
+        // but the in-place leaf at nibble 0x2 is marked private.
+        // This tests that process_branch correctly updates the privacy flag
+        // for in-place encoded leaves.
+        //
+        // root (branch)
+        //  ├─ 0x2 : leaf (key suffix = [0xa], value=0x64, private=true)   <-- target
+        //  ├─ 0x3 : branch (in-place) with leaves [0xa] and [0xb], public
+        //  └─ 0x4 : extension [0x1] -> branch (in-place) with leaves [0xa] and [0xb], public
+
+        let mut buffer = vec![];
+        let value = vec![0x64];
+
+        // Child at nibble 0x2: a private in-place leaf.
+        let child_leaf =
+            TrieNode::Leaf(LeafNode::new(Nibbles::from_nibbles([0xa]), value.clone(), true));
+
+        // Child at nibble 0x3: an in-place branch with two public leaves.
+        let child_branch = TrieNode::Branch(BranchNode::new(
+            vec![
+                {
+                    buffer.clear();
+                    TrieNode::Leaf(LeafNode::new(
+                        Nibbles::from_nibbles([0xa]),
+                        value.clone(),
+                        false,
+                    ))
+                    .rlp(&mut buffer)
+                },
+                {
+                    buffer.clear();
+                    TrieNode::Leaf(LeafNode::new(
+                        Nibbles::from_nibbles([0xb]),
+                        value.clone(),
+                        false,
+                    ))
+                    .rlp(&mut buffer)
+                },
+            ],
+            TrieMask::new(0b0000000000001100_u16),
+        ));
+
+        // Child at nibble 0x4: extension [0x1] -> in-place branch with two public leaves.
+        let child_extension =
+            TrieNode::Extension(ExtensionNode::new(Nibbles::from_nibbles([0x1]), {
+                buffer.clear();
+                child_branch.rlp(&mut buffer)
+            }));
+
+        let root_branch = TrieNode::Branch(BranchNode::new(
+            vec![
+                {
+                    buffer.clear();
+                    child_leaf.rlp(&mut buffer)
+                },
+                {
+                    buffer.clear();
+                    child_branch.rlp(&mut buffer)
+                },
+                {
+                    buffer.clear();
+                    child_extension.rlp(&mut buffer)
+                },
+            ],
+            TrieMask::new(0b0000000000011100_u16),
+        ));
+
+        let mut root_encoded = vec![];
+        root_branch.encode(&mut root_encoded);
+
+        let root_hash = alloy_primitives::keccak256(&root_encoded);
+        let root_encoded = Bytes::from(root_encoded);
+        let proof = vec![&root_encoded];
+
+        // Private in-place leaf at path [0x2, 0xa] should verify as private.
+        verify_proof(
+            root_hash,
+            Nibbles::from_nibbles([0x2, 0xa]),
+            Some(vec![0x64]),
+            true,
+            proof.clone(),
+        )
+        .unwrap();
+
+        // The same leaf should fail verification when claimed to be public.
+        assert!(
+            verify_proof(
+                root_hash,
+                Nibbles::from_nibbles([0x2, 0xa]),
+                Some(vec![0x64]),
+                false,
+                proof.clone(),
+            )
+            .is_err()
+        );
+
+        // Public in-place leaves at [0x3, 0x2, 0xa] should still verify as public.
+        verify_proof(
+            root_hash,
+            Nibbles::from_nibbles([0x3, 0x2, 0xa]),
+            Some(vec![0x64]),
+            false,
+            proof.clone(),
+        )
+        .unwrap();
+
+        // Public in-place leaf via extension at [0x4, 0x1, 0x2, 0xa] should verify as public.
+        verify_proof(
+            root_hash,
+            Nibbles::from_nibbles([0x4, 0x1, 0x2, 0xa]),
+            Some(vec![0x64]),
+            false,
             proof.clone(),
         )
         .unwrap();


### PR DESCRIPTION
Fixes veridise issue 800.

## Veridise Report

Proof verification is performed in verify_proof(), which iterates over the proof nodes, descends the trie using process_trie_node() and process_branch(), and finally compares the resolved value and its privacy flag against the expected value and privacy. Privacy tracking during this process relies on a mutable flag, last_decoded_node_is_private, which is intended to reflect the privacy of the leaf node that ultimately resolves the proof.

Currently, this flag is updated only when a leaf node is decoded at the top level inside process_trie_node. When such a leaf is encountered, the decoded leaf’s is_private bit is written into last_decoded_node_is_private before returning the value.



Snippet from process_trie_node()
```
TrieNode::Leaf(leaf) => {
    walked_path.extend(&leaf.key);
    *last_decoded_node_is_private = leaf.is_private;
    Some(NodeDecodingResult::Value(leaf.value))
}
```

However, when verification descends through a branch and encounters a leaf that is encoded in place, the privacy flag is not updated. In process_branch(), the in-place leaf case returns the decoded value directly without modifying last_decoded_node_is_private. See snippet below for reference.


Snippet from process_branch()
```
TrieNode::Leaf(child_leaf) => {
    walked_path.extend(&child_leaf.key);
    return Ok(Some(NodeDecodingResult::Value(child_leaf.value)));
}
```

At the end of verification, verify_proof() compares both the resolved value and the value of last_decoded_node_is_private against the expected privacy. Because in-place leaf decoding does not update the privacy flag, this final comparison may use stale privacy information inherited from a previously decoded node rather than the actual is_private bit of the resolved leaf.


Snippet from verify_proof()
```
if last_decoded_node.as_deref() == expected_value.as_deref()
    && last_decoded_node_is_private == expected_is_private
```

As a result, proofs that resolve to in-place leaves may be accepted or rejected incorrectly due to the use of a stale privacy flag.

Impact

A private in-place leaf may fail verification even when the value is correct, while a public in-place leaf may be misclassified as private depending on the prior traversal state. This breaks the correctness guarantee that proof verification enforces both value integrity and privacy consistency under Seismic’s flagged storage model.