### PR TITLE
fix: reject empty proofs with trailing nodes

### DIFF
--- a/src/proof/error.rs
+++ b/src/proof/error.rs
@@ -27,6 +27,8 @@ pub enum ProofVerificationError {
     },
     /// Encountered unexpected empty root node.
     UnexpectedEmptyRoot,
+    /// Proof contains trailing nodes after the expected end.
+    TrailingProofNodes,
     /// Error during RLP decoding of trie node.
     Rlp(alloy_rlp::Error),
 }
@@ -60,6 +62,9 @@ impl fmt::Display for ProofVerificationError {
             }
             Self::UnexpectedEmptyRoot => {
                 write!(f, "unexpected empty root node")
+            }
+            Self::TrailingProofNodes => {
+                write!(f, "proof contains trailing nodes after the expected end")
             }
             Self::Rlp(error) => fmt::Display::fmt(error, f),
         }

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -796,6 +796,31 @@ mod tests {
     }
 
     #[test]
+    fn empty_proof_with_trailing_nodes_is_rejected() {
+        // Demonstrates the bug: a proof like [EMPTY, junk...] is accepted as a valid
+        // exclusion proof when root == EMPTY_ROOT_HASH and expected_value == None.
+        // The trailing junk bytes should cause verification to fail.
+        let key = Nibbles::unpack(B256::repeat_byte(42));
+        let proof_with_junk = vec![
+            Bytes::from([EMPTY_STRING_CODE]),
+            Bytes::from(vec![0xDE, 0xAD]),
+        ];
+        let result = verify_proof(
+            EMPTY_ROOT_HASH,
+            key,
+            None,
+            false,
+            proof_with_junk.iter(),
+        );
+        // After the fix, this should be Err (trailing proof nodes).
+        // Before the fix, this incorrectly returns Ok(()).
+        assert!(
+            result.is_err(),
+            "proof with trailing nodes after empty node should be rejected"
+        );
+    }
+
+    #[test]
     #[cfg(feature = "arbitrary")]
     #[cfg_attr(miri, ignore = "no proptest")]
     fn arbitrary_proof_verification() {

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -29,6 +29,11 @@ where
 
     // If the proof is empty or contains only an empty node, the expected value must be None.
     if proof.peek().is_none_or(|node| node.as_ref() == [EMPTY_STRING_CODE]) {
+        // Consume the first element (if any), then ensure no trailing nodes remain.
+        proof.next();
+        if proof.next().is_some() {
+            return Err(ProofVerificationError::TrailingProofNodes);
+        }
         return if root == EMPTY_ROOT_HASH {
             if expected_value.is_none() {
                 Ok(())


### PR DESCRIPTION
## Summary
- Fixes lenient handling of empty proofs in `verify_proof` where proofs like `[EMPTY, junk...]` were incorrectly accepted as valid exclusion proofs
- After peeking to identify the empty proof case, the fix now consumes the first element and checks that no trailing nodes remain
- Adds a new `TrailingProofNodes` error variant to `ProofVerificationError`

## Test plan
- [x] Added test `empty_proof_with_trailing_nodes_is_rejected` that crafts a proof with `[EMPTY_STRING_CODE, 0xDEAD]` and verifies it is rejected
- [x] All existing tests pass (`cargo test` — 32 passed, 0 failed)

Fixes SeismicSystems/internal#207