### PR TITLE
fix: use expected_is_private in empty-root verify_proof path

### DIFF
--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -38,7 +38,7 @@ where
                     got: None,
                     expected: expected_value.map(Bytes::from),
                     got_private: false,
-                    expected_private: true,
+                    expected_private: expected_is_private,
                 })
             }
         } else {

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -796,6 +796,23 @@ mod tests {
     }
 
     #[test]
+    fn empty_root_value_mismatch_uses_expected_private() {
+        let key = Nibbles::unpack(B256::repeat_byte(42));
+        let proof = vec![Bytes::from([EMPTY_STRING_CODE])];
+        let result = verify_proof(EMPTY_ROOT_HASH, key, Some(vec![0x01]), false, proof.iter());
+        assert_eq!(
+            result,
+            Err(ProofVerificationError::ValueMismatch {
+                path: key,
+                got: None,
+                expected: Some(Bytes::from(vec![0x01])),
+                got_private: false,
+                expected_private: false,
+            })
+        );
+    }
+
+    #[test]
     #[cfg(feature = "arbitrary")]
     #[cfg_attr(miri, ignore = "no proptest")]
     fn arbitrary_proof_verification() {


### PR DESCRIPTION
## Summary
- Fixes the `verify_proof` empty-root fast path that hardcoded `expected_private: true` in the `ValueMismatch` error, instead of using the caller-provided `expected_is_private` parameter.
- Adds a targeted test (`empty_root_value_mismatch_uses_expected_private`) that verifies the error reflects the correct `expected_private` value.

Fixes SeismicSystems/internal#209

## Test plan
- [x] New unit test covers the empty-root path with `expected_is_private: false` and asserts `expected_private: false` in the error
- [x] All existing tests pass (`cargo test` -- 32 passed)