### PR TITLE
fix: replace unreachable panic with error in verify_proof

### DIFF
--- a/src/proof/error.rs
+++ b/src/proof/error.rs
@@ -27,6 +27,9 @@ pub enum ProofVerificationError {
     },
     /// Encountered unexpected empty root node.
     UnexpectedEmptyRoot,
+    /// Encountered an unexpected child node type (e.g., Leaf, Extension, or EmptyRoot)
+    /// inside an inline extension node where only a Branch is valid.
+    UnexpectedNodeChild(alloc::string::String),
     /// Error during RLP decoding of trie node.
     Rlp(alloy_rlp::Error),
 }
@@ -60,6 +63,9 @@ impl fmt::Display for ProofVerificationError {
             }
             Self::UnexpectedEmptyRoot => {
                 write!(f, "unexpected empty root node")
+            }
+            Self::UnexpectedNodeChild(msg) => {
+                write!(f, "unexpected node child: {msg}")
             }
             Self::Rlp(error) => fmt::Display::fmt(error, f),
         }

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -795,6 +795,36 @@ mod tests {
         .unwrap();
     }
 
+    /// Regression test for audit finding: malicious proof with an inline extension node
+    /// whose child is a leaf (not a branch) should return an error instead of panicking.
+    #[test]
+    fn malicious_proof_unexpected_extension_child_returns_error() {
+        let leaf = LeafNode::new(Nibbles::from_nibbles([0x2]), vec![0x01], false);
+        let mut leaf_rlp = Vec::new();
+        let leaf_node = leaf.as_ref().rlp(&mut leaf_rlp);
+
+        let extension = ExtensionNode::new(Nibbles::from_nibbles([0x1]), leaf_node);
+        let mut extension_rlp = Vec::new();
+        let extension_node = extension.as_ref().rlp(&mut extension_rlp);
+        assert!(extension_rlp.len() < 32, "extension node should be inline");
+
+        let other_child = RlpNode::word_rlp(&B256::repeat_byte(0x11));
+        let state_mask = TrieMask::from_nibble(0) | TrieMask::from_nibble(1);
+        let branch = BranchNode::new(vec![extension_node, other_child], state_mask);
+
+        let mut branch_rlp = Vec::new();
+        branch.as_ref().rlp(&mut branch_rlp);
+        assert!(branch_rlp.len() >= 32, "branch node should be hashed at root");
+
+        let root = alloy_primitives::keccak256(&branch_rlp);
+        let proof = vec![Bytes::from(branch_rlp)];
+        let key = Nibbles::from_nibbles([0x0]);
+
+        // Before the fix, this would panic with `unreachable!` instead of returning an error.
+        let result = verify_proof(root, key, None, false, proof.iter());
+        assert!(result.is_err(), "should return error, not panic");
+    }
+
     #[test]
     #[cfg(feature = "arbitrary")]
     #[cfg_attr(miri, ignore = "no proptest")]

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -193,7 +193,9 @@ fn process_branch(
                                     node @ (TrieNode::EmptyRoot
                                     | TrieNode::Extension(_)
                                     | TrieNode::Leaf(_)) => {
-                                        unreachable!("unexpected extension node child: {node:?}")
+                                        return Err(ProofVerificationError::UnexpectedNodeChild(
+                                            alloc::format!("{node:?}"),
+                                        ));
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary
- Replaces `unreachable!` panic in `process_branch` with a proper `ProofVerificationError::UnexpectedNodeChild` error return, preventing DoS via malicious proofs that contain an inline extension node with a non-branch child (Leaf, Extension, or EmptyRoot).
- Adds a new `UnexpectedNodeChild(String)` variant to `ProofVerificationError` with Display and Error trait support.
- Includes a regression test that constructs a malicious proof triggering the previously-panicking code path.

## Test plan
- [x] Regression test `malicious_proof_unexpected_extension_child_returns_error` verifies the fix
- [x] Full `cargo test` suite passes (32 tests)

Fixes SeismicSystems/internal#205