### PR TITLE
fix: reject empty proofs with trailing nodes

### DIFF
--- a/src/proof/error.rs
+++ b/src/proof/error.rs
@@ -27,6 +27,8 @@ pub enum ProofVerificationError {
     },
     /// Encountered unexpected empty root node.
     UnexpectedEmptyRoot,
+    /// Proof contains trailing nodes after the expected end.
+    TrailingProofNodes,
     /// Error during RLP decoding of trie node.
     Rlp(alloy_rlp::Error),
 }
@@ -60,6 +62,9 @@ impl fmt::Display for ProofVerificationError {
             }
             Self::UnexpectedEmptyRoot => {
                 write!(f, "unexpected empty root node")
+            }
+            Self::TrailingProofNodes => {
+                write!(f, "proof contains trailing nodes after the expected end")
             }
             Self::Rlp(error) => fmt::Display::fmt(error, f),
         }

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -823,23 +823,11 @@ mod tests {
         // exclusion proof when root == EMPTY_ROOT_HASH and expected_value == None.
         // The trailing junk bytes should cause verification to fail.
         let key = Nibbles::unpack(B256::repeat_byte(42));
-        let proof_with_junk = vec![
-            Bytes::from([EMPTY_STRING_CODE]),
-            Bytes::from(vec![0xDE, 0xAD]),
-        ];
-        let result = verify_proof(
-            EMPTY_ROOT_HASH,
-            key,
-            None,
-            false,
-            proof_with_junk.iter(),
-        );
+        let proof_with_junk = vec![Bytes::from([EMPTY_STRING_CODE]), Bytes::from(vec![0xDE, 0xAD])];
+        let result = verify_proof(EMPTY_ROOT_HASH, key, None, false, proof_with_junk.iter());
         // After the fix, this should be Err (trailing proof nodes).
         // Before the fix, this incorrectly returns Ok(()).
-        assert!(
-            result.is_err(),
-            "proof with trailing nodes after empty node should be rejected"
-        );
+        assert!(result.is_err(), "proof with trailing nodes after empty node should be rejected");
     }
 
     #[test]

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -813,6 +813,31 @@ mod tests {
     }
 
     #[test]
+    fn empty_proof_with_trailing_nodes_is_rejected() {
+        // Demonstrates the bug: a proof like [EMPTY, junk...] is accepted as a valid
+        // exclusion proof when root == EMPTY_ROOT_HASH and expected_value == None.
+        // The trailing junk bytes should cause verification to fail.
+        let key = Nibbles::unpack(B256::repeat_byte(42));
+        let proof_with_junk = vec![
+            Bytes::from([EMPTY_STRING_CODE]),
+            Bytes::from(vec![0xDE, 0xAD]),
+        ];
+        let result = verify_proof(
+            EMPTY_ROOT_HASH,
+            key,
+            None,
+            false,
+            proof_with_junk.iter(),
+        );
+        // After the fix, this should be Err (trailing proof nodes).
+        // Before the fix, this incorrectly returns Ok(()).
+        assert!(
+            result.is_err(),
+            "proof with trailing nodes after empty node should be rejected"
+        );
+    }
+
+    #[test]
     #[cfg(feature = "arbitrary")]
     #[cfg_attr(miri, ignore = "no proptest")]
     fn arbitrary_proof_verification() {

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -29,6 +29,11 @@ where
 
     // If the proof is empty or contains only an empty node, the expected value must be None.
     if proof.peek().is_none_or(|node| node.as_ref() == [EMPTY_STRING_CODE]) {
+        // Consume the first element (if any), then ensure no trailing nodes remain.
+        proof.next();
+        if proof.next().is_some() {
+            return Err(ProofVerificationError::TrailingProofNodes);
+        }
         return if root == EMPTY_ROOT_HASH {
             if expected_value.is_none() {
                 Ok(())


### PR DESCRIPTION
## Summary

- Empty proofs (or proofs starting with `EMPTY_STRING_CODE`) were accepted even with trailing junk nodes
- Added `TrailingProofNodes` error variant; after accepting the empty node, verify no remaining elements exist

Addresses [SeismicSystems/internal#207](https://github.com/SeismicSystems/internal/issues/207).

## Test plan
- `empty_proof_with_trailing_nodes_is_rejected` regression test
- All existing tests pass