### PR TITLE
fix: replace unreachable panic with error in verify_proof

### DIFF
--- a/src/proof/error.rs
+++ b/src/proof/error.rs
@@ -43,6 +43,9 @@ pub enum ProofVerificationError {
         /// The maximum allowed number of nodes.
         max: usize,
     },
+    /// Encountered an unexpected child node type (e.g., Leaf, Extension, or EmptyRoot)
+    /// inside an inline extension node where only a Branch is valid.
+    UnexpectedNodeChild(alloc::string::String),
     /// Error during RLP decoding of trie node.
     Rlp(alloy_rlp::Error),
 }
@@ -85,6 +88,9 @@ impl fmt::Display for ProofVerificationError {
             }
             Self::TooManyProofNodes { got, max } => {
                 write!(f, "proof node count {got} exceeds maximum {max}")
+            }
+            Self::UnexpectedNodeChild(msg) => {
+                write!(f, "unexpected node child: {msg}")
             }
             Self::Rlp(error) => fmt::Display::fmt(error, f),
         }

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -227,7 +227,9 @@ fn process_branch(
                                     node @ (TrieNode::EmptyRoot
                                     | TrieNode::Extension(_)
                                     | TrieNode::Leaf(_)) => {
-                                        unreachable!("unexpected extension node child: {node:?}")
+                                        return Err(ProofVerificationError::UnexpectedNodeChild(
+                                            alloc::format!("{node:?}"),
+                                        ));
                                     }
                                 }
                             }

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -829,6 +829,36 @@ mod tests {
         .unwrap();
     }
 
+    /// Regression test for audit finding: malicious proof with an inline extension node
+    /// whose child is a leaf (not a branch) should return an error instead of panicking.
+    #[test]
+    fn malicious_proof_unexpected_extension_child_returns_error() {
+        let leaf = LeafNode::new(Nibbles::from_nibbles([0x2]), vec![0x01], false);
+        let mut leaf_rlp = Vec::new();
+        let leaf_node = leaf.as_ref().rlp(&mut leaf_rlp);
+
+        let extension = ExtensionNode::new(Nibbles::from_nibbles([0x1]), leaf_node);
+        let mut extension_rlp = Vec::new();
+        let extension_node = extension.as_ref().rlp(&mut extension_rlp);
+        assert!(extension_rlp.len() < 32, "extension node should be inline");
+
+        let other_child = RlpNode::word_rlp(&B256::repeat_byte(0x11));
+        let state_mask = TrieMask::from_nibble(0) | TrieMask::from_nibble(1);
+        let branch = BranchNode::new(vec![extension_node, other_child], state_mask);
+
+        let mut branch_rlp = Vec::new();
+        branch.as_ref().rlp(&mut branch_rlp);
+        assert!(branch_rlp.len() >= 32, "branch node should be hashed at root");
+
+        let root = alloy_primitives::keccak256(&branch_rlp);
+        let proof = vec![Bytes::from(branch_rlp)];
+        let key = Nibbles::from_nibbles([0x0]);
+
+        // Before the fix, this would panic with `unreachable!` instead of returning an error.
+        let result = verify_proof(root, key, None, false, proof.iter());
+        assert!(result.is_err(), "should return error, not panic");
+    }
+
     #[test]
     fn empty_root_value_mismatch_uses_expected_private() {
         let key = Nibbles::unpack(B256::repeat_byte(42));


### PR DESCRIPTION
## Summary

- `process_branch` used `unreachable!` when an inline extension node's child decoded as a Leaf/Extension/EmptyRoot, allowing a malicious proof to trigger a panic (DoS)
- Replaced with `ProofVerificationError::UnexpectedNodeChild` error return

Addresses [SeismicSystems/internal#205](https://github.com/SeismicSystems/internal/issues/205).

## Test plan
- `malicious_proof_unexpected_extension_child_returns_error` regression test
- All existing tests pass