### PR TITLE
ci: enable seismic CI on zellic-audit-feb-2026 branch

### DIFF
--- a/.github/workflows/seismic.yml
+++ b/.github/workflows/seismic.yml
@@ -2,9 +2,9 @@ name: Seismic CI
 
 on:
   push:
-    branches: [seismic]
+    branches: [seismic, zellic-audit-feb-2026]
   pull_request:
-    branches: [seismic]
+    branches: [seismic, zellic-audit-feb-2026]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Adds `zellic-audit-feb-2026` to the push and pull_request branch triggers in `seismic.yml` so the full CI suite runs on PRs into this branch.