### PR TITLE
fix: use expected_is_private instead of hardcoded true in empty-root path

### DIFF
--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -38,7 +38,7 @@ where
                     got: None,
                     expected: expected_value.map(Bytes::from),
                     got_private: false,
-                    expected_private: true,
+                    expected_private: expected_is_private,
                 })
             }
         } else {

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -927,6 +927,23 @@ mod tests {
     }
 
     #[test]
+    fn empty_root_value_mismatch_uses_expected_private() {
+        let key = Nibbles::unpack(B256::repeat_byte(42));
+        let proof = vec![Bytes::from([EMPTY_STRING_CODE])];
+        let result = verify_proof(EMPTY_ROOT_HASH, key, Some(vec![0x01]), false, proof.iter());
+        assert_eq!(
+            result,
+            Err(ProofVerificationError::ValueMismatch {
+                path: key,
+                got: None,
+                expected: Some(Bytes::from(vec![0x01])),
+                got_private: false,
+                expected_private: false,
+            })
+        );
+    }
+
+    #[test]
     #[cfg(feature = "arbitrary")]
     #[cfg_attr(miri, ignore = "no proptest")]
     fn arbitrary_proof_verification() {


### PR DESCRIPTION
## Summary

Addresses the Veridise finding: "Proof verification function uses static boolean when constructing value mismatch errors."

Cherry-pick of the #209 fix (from [PR #31](https://github.com/SeismicSystems/seismic-trie/pull/31)) onto `veridise-audit-feb-2026`.

In `verify_proof`'s empty-root fast path, the `ValueMismatch` error hardcoded `expected_private: true` instead of using the caller-provided `expected_is_private` parameter.

## Test plan
- `empty_root_value_mismatch_uses_expected_private` regression test
- All existing tests pass