### PR TITLE
chore: add lefthook configuration

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,5 @@
+pre-commit:
+  commands:
+    fmt:
+      run: cargo +nightly fmt --all
+      stage_fixed: true


### PR DESCRIPTION
## Summary
- Adds `lefthook.yml` with a pre-commit hook that runs `cargo +nightly fmt --all` to auto-format code before each commit
- Matches the `cargo fmt` check already in CI (`seismic.yml`)

## Setup
After merging, each developer needs to run `lefthook install` once in their local clone.