### PR TITLE
fix(test): drop stray debug `println!`s that break the no_std test build

### DIFF
--- a/src/nodes/leaf.rs
+++ b/src/nodes/leaf.rs
@@ -201,7 +201,6 @@ mod tests {
     fn rlp_leaf_node_roundtrip() {
         // Public leaf node
         let nibble = Nibbles::from_nibbles_unchecked(hex!("0604060f"));
-        println!("nibble: {:?}", nibble);
         let val = hex!("76657262");
 
         let leaf = LeafNode::new(nibble.clone(), val.to_vec(), false);

--- a/src/proof/verify.rs
+++ b/src/proof/verify.rs
@@ -375,7 +375,6 @@ mod tests {
         assert_eq!(root, triehash_trie_root([(target.pack(), target.pack())]));
 
         let proof = hash_builder.take_proof_nodes().into_nodes_sorted();
-        println!("{:?}", proof);
         assert_eq!(
             verify_proof(
                 root,


### PR DESCRIPTION
`cargo test --workspace --no-default-features` does not compile on `seismic`:

```
error: cannot find macro `println` in this scope
  --> src/nodes/leaf.rs:204:9
error: cannot find macro `println` in this scope
  --> src/proof/verify.rs:378:9
error: could not compile `alloy-trie` (lib test) due to 2 previous errors
```

Both are leftover debugging prints inside `#[cfg(test)]` code. Under
`--no-default-features` the crate is `no_std`, so `println!` is not in scope and the
entire lib test target fails to build — the tests in that configuration never run at all.

### Scope

To be clear about how much this matters: **no currently active workflow runs this
command.** `CI` and `bench` are `disabled_manually` in this repo, so `ci.yml`'s
`cargo test --workspace ${{ matrix.flags }}` matrix never fires. The two active
workflows are unaffected — `Seismic CI` runs `cargo test` with default features, and
`no_std` runs `cargo check` (which compiles the lib, not the `#[cfg(test)]` code).

So this is a latent defect rather than a red check: it hits anyone running the
`no_std` test configuration locally, and it would surface immediately if `CI` were
re-enabled. Sending it as a small standalone fix so that lane is buildable whenever
you want to look at it.

### Change

Removes the two lines. Neither print carried information the tests assert on, and the
surrounding assertions are untouched.

The three `println!`s in `HashBuilder::print_stack` are deliberate and correctly gated
behind `#[cfg(feature = "std")]`, so they are left alone.

### Verification

| check | result |
|---|---|
| `cargo test --workspace --no-default-features` | **37 passed** (previously did not compile) |
| `cargo test --workspace` | 37 passed |
| `cargo test --workspace --all-features` | 47 passed |
| `cargo clippy --workspace --all-targets --all-features` | unchanged from base branch |
| `cargo fmt --check` | clean |
